### PR TITLE
fix error "descriptor 'split' requires a 'str' object but received a …

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -73,7 +73,7 @@ class MaxCube(MaxDevice):
 
     def parse_response(self, response):
 
-        lines = str.split(response, '\n')
+        lines = response.split('\n')
 
         for line in lines:
             line = line.strip()


### PR DESCRIPTION
Fix error "descriptor 'split' requires a 'str' object but received a 'unicode'".
